### PR TITLE
Add registries patterns

### DIFF
--- a/registries.yml
+++ b/registries.yml
@@ -1,0 +1,4 @@
+PyPi : 'PyPi(.*)https://badge.fury.io/py/(.*).svg'
+Julia : 'http://pkg.julialang.org/badges/(.*).svg'
+CRAN: 'https://www.r-pkg.org/badges/version/'
+ROpenSci: 'https://badges.ropensci.org/(.*).svg'


### PR DESCRIPTION
Add registries patterns in 'registries.yml' file. The structure is
[name of the registry] : '[pattern]'

It is meant to be read out into the dictionary, with registry names as keys.